### PR TITLE
fix: implement `appDir` studio loading

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -1,7 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-.sanity > div {
-    height: 100vh;
-}

--- a/lib/sanity/api.ts
+++ b/lib/sanity/api.ts
@@ -1,0 +1,16 @@
+/**
+ * Find your project ID and dataset in `sanity.json` in your studio project.
+ * These are considered “public”, but you can use environment variables
+ * if you want differ between local dev and production.
+ *
+ * https://nextjs.org/docs/basic-features/environment-variables
+ **/
+export const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+export const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+export const apiVersion = "2021-03-25";
+/**
+ * Set useCdn to `false` if your application require the freshest possible
+ * data always (potentially slightly slower and a bit more expensive).
+ * Authenticated request (like preview) will always bypass the CDN
+ **/
+export const useCdn = process.env.NODE_ENV === "production";

--- a/lib/sanity/config.ts
+++ b/lib/sanity/config.ts
@@ -4,25 +4,14 @@ import { defineConfig } from "sanity";
 import { deskTool } from "sanity/desk";
 import { codeInput } from "@sanity/code-input";
 
+import { projectId, dataset, apiVersion } from "./api";
+
 export default defineConfig({
   basePath: "/studio",
-  /**
-   * Find your project ID and dataset in `sanity.json` in your studio project.
-   * These are considered “public”, but you can use environment variables
-   * if you want differ between local dev and production.
-   *
-   * https://nextjs.org/docs/basic-features/environment-variables
-   **/
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
-  apiVersion: "2021-03-25",
+  projectId,
+  dataset,
+  apiVersion,
   title: process.env.NEXT_PUBLIC_SANITY_PROJECT_TITLE || "alvar.dev",
-  /**
-   * Set useCdn to `false` if your application require the freshest possible
-   * data always (potentially slightly slower and a bit more expensive).
-   * Authenticated request (like preview) will always bypass the CDN
-   **/
-  useCdn: process.env.NODE_ENV === "production",
   plugins: [
     deskTool(),
     codeInput(),

--- a/lib/sanity/sanity.server.ts
+++ b/lib/sanity/sanity.server.ts
@@ -1,5 +1,5 @@
 import { createClient } from "next-sanity";
-import config from "./config";
+import * as config from "./api";
 
 // Set up the client for fetching data in the getProps page functions
 export const sanityClient = createClient(config);

--- a/lib/sanity/sanity.ts
+++ b/lib/sanity/sanity.ts
@@ -1,16 +1,13 @@
-import { createPreviewSubscriptionHook, createCurrentUserHook } from "next-sanity";
+import { definePreview } from "next-sanity/preview";
 import createImageUrlBuilder from "@sanity/image-url";
 
-import config from "./config";
+import { projectId, dataset } from "./api";
 
 /**
  * Set up a helper function for generating Image URLs with only the asset reference data in your documents.
  * Read more: https://www.sanity.io/docs/image-url
  **/
-export const urlFor = source => createImageUrlBuilder(config).image(source);
+export const urlFor = source => createImageUrlBuilder({ projectId, dataset }).image(source);
 
 // Set up the live preview subscription hook
-export const usePreviewSubscription = createPreviewSubscriptionHook(config);
-
-// Helper function for using the current logged in user account
-export const useCurrentUser = createCurrentUserHook(config);
+export const usePreview = definePreview({ projectId, dataset });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@next/font": "13.0.5",
     "@portabletext/react": "2.0.0",
-    "@sanity/code-input": "^3.0.0-v3-studio.15",
+    "@sanity/code-input": "3.0.0",
     "@tailwindcss/typography": "0.5.7",
     "@vercel/og": "0.0.20",
     "feed": "4.2.2",
@@ -22,7 +22,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-syntax-highlighter": "15.5.0",
-    "sanity": "3.0.0-rc.0"
+    "sanity": "3.0.0-rc.3",
+    "styled-components": "^5.3.6"
   },
   "devDependencies": {
     "@playwright/test": "1.28.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@next/font": "13.0.5",
     "@portabletext/react": "2.0.0",
-    "@sanity/code-input": "3.0.0",
+    "@sanity/code-input": "3.0.1",
     "@tailwindcss/typography": "0.5.7",
     "@vercel/og": "0.0.20",
     "feed": "4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,7 +52,16 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.18.6":
+"@babel/generator@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.5.tgz#cb25abee3178adf58d6814b68517c62bdbfdda95"
+  integrity sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==
+  dependencies:
+    "@babel/types" "^7.20.5"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/helper-annotate-as-pure@^7.16.0", "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
   integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
@@ -89,7 +98,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-imports@^7.18.6":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.0", "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
@@ -166,6 +175,11 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.2.tgz#9aeb9b92f64412b5f81064d46f6a1ac0881337f4"
   integrity sha512-afk318kh2uKbo7BEj2QtEi8HVCGrwHUffrYDy7dgVcSa2j9lY3LDjPzcyGdpX7xgm35aWqvciZJ4WKmdF/SxYg==
+
+"@babel/parser@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
+  integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
 
 "@babel/plugin-syntax-jsx@^7.18.6":
   version "7.18.6"
@@ -246,10 +260,35 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.4.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
+  integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.5"
+    "@babel/types" "^7.20.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.2.tgz#67ac09266606190f496322dbaff360fdaa5e7842"
   integrity sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
+  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
@@ -262,10 +301,32 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/memoize@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
+  integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@esbuild/android-arm@0.15.13":
   version "0.15.13"
@@ -657,18 +718,18 @@
     nanoid "^3.1.12"
     rxjs "^6.4.0"
 
-"@sanity/block-tools@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/block-tools/-/block-tools-3.0.0-rc.0.tgz#d75254f569e7421bb16599ca3eabc266274a482f"
-  integrity sha512-YCZBKLXPNkAKNBYFN79SCUG9Ee/CEUerbO3nMJV0uoxexlVPAt0pq2zUqjI2oyN3oAfy0+1iABOgtPVQlJyc/w==
+"@sanity/block-tools@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/block-tools/-/block-tools-3.0.0-rc.3.tgz#fed99ec0f9225ed173914963b34f03137be1c7a2"
+  integrity sha512-ITP54+x/RYSsLjh1pjxITTtPXEbEaSYVSiMAWRiia+huvlrKytbbD+UOP2Z2mUSFXlpE0ZhIJ4mbXx0sWcyu1A==
   dependencies:
     get-random-values-esm "^1.0.0"
     lodash "^4.17.21"
 
-"@sanity/cli@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/cli/-/cli-3.0.0-rc.0.tgz#f411fbf1eeb359351f7d40bfe4c295de1a8a723b"
-  integrity sha512-sfTRQQ+0ELms4pi3tTjRR85e0KOpD9bZsNzWf5EaGS3pPFvwsqI40CqmeDq+7izYmYisvj47jL9j0uNis0OUug==
+"@sanity/cli@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/cli/-/cli-3.0.0-rc.3.tgz#9749a6c3e0096e87760dad581a22d672184a881e"
+  integrity sha512-gHrVLiqUc15wxif0JtQC7YlCkAbThb9FWhhcUYEjJF1uKmwlqs/Uj2jwQFCp0W5I9iqlRe5ol3CQktBO3XxoxA==
   dependencies:
     "@babel/traverse" "^7.19.0"
     esbuild "^0.14.43"
@@ -687,31 +748,31 @@
     object-assign "^4.1.1"
     rxjs "^6.0.0"
 
-"@sanity/code-input@^3.0.0-v3-studio.15":
-  version "3.0.0-v3-studio.15"
-  resolved "https://registry.yarnpkg.com/@sanity/code-input/-/code-input-3.0.0-v3-studio.15.tgz#db7e54b2d02a3555c874fdfaf77d7b2f3e409023"
-  integrity sha512-70d0c8Cpp1EaHFGLC47N7DYMxf4nfNGKIfYFxPT7dhsvoVyDF+WAAkZdO3P6yRpwc3d7fPub3GtYbFvz4Sru5g==
+"@sanity/code-input@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sanity/code-input/-/code-input-3.0.0.tgz#ca4d01a9cdb956b8321d3d745dc39462d4de6df1"
+  integrity sha512-Ov6csC/t2i6qZbbylGodhMmaygsX/t/TxjCG1L+oGPJNXu3mXQDG8/3PQmZl1Zac1Do90+72eK4/x/xj/+QHBA==
   dependencies:
-    "@sanity/icons" "^1.2.8"
+    "@sanity/icons" "^2.0.0"
     "@sanity/incompatible-plugin" "^1.0.4"
-    "@sanity/ui" "1.0.0-beta.32"
+    "@sanity/ui" "^1.0.0"
     ace-builds "^1.9.5"
     react-ace "^10.1.0"
-
-"@sanity/color@2.1.19-beta.3":
-  version "2.1.19-beta.3"
-  resolved "https://registry.yarnpkg.com/@sanity/color/-/color-2.1.19-beta.3.tgz#f4f9a377825f332a9908e3ffb4945dccccc3f73b"
-  integrity sha512-421F+o3BbumkPzj93wsM9VXeX4wuhrXp/B/AHVuB0uXWLEGYnrY2mBzRU44fsZGQWW4fgy139B5eV5orFzYJkA==
 
 "@sanity/color@^2.1.14":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@sanity/color/-/color-2.1.16.tgz#4d4b36874279e1801c89827c6eb3332c960a729f"
   integrity sha512-R5Wh4qt+Jv20nvwSwE5xA+eS3kF2diPA6noAPQZSUsSG9UIUGGgxJyU0hWUa9O06RTCNqgBQI1YJiZTeJ6S7SA==
 
-"@sanity/diff@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/diff/-/diff-3.0.0-rc.0.tgz#9f1b4705a96f8a3d00aa190ea2b3cb3fe9ea3234"
-  integrity sha512-MVhtu1Iq49o7OpBAD+VfDGc/0Lg/HhZ41FIqtMHPzQTaW5zDODzaPE3LxeM3RFT3ZHBJz1pKYutr3y94aENIaA==
+"@sanity/color@^2.1.20":
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/@sanity/color/-/color-2.1.20.tgz#48c6ad3e6333d1da2989acbead1a46b4a8c5347a"
+  integrity sha512-dHPgiCMf+lwvQls5uPzorfiq9YuU41AzvifA+ugVHmXvq7JBoofoOPUOmdHUQF0l0shSy0nD3zn52j2I+T2ekg==
+
+"@sanity/diff@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/diff/-/diff-3.0.0-rc.3.tgz#5681d38b06410e18da34e792f06ec82f180d0d6c"
+  integrity sha512-WlKSJiSWXmOBmk2DTFgSrt9Q7HtrCA5J5nHvIqngdTQ8BHDS4Fwg0EWwRi5u/JteMxmSrfuia7oQiocsFdNpxA==
   dependencies:
     diff-match-patch "^1.0.4"
 
@@ -731,10 +792,10 @@
     event-source-polyfill "1.0.25"
     eventsource "^2.0.2"
 
-"@sanity/export@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/export/-/export-3.0.0-rc.0.tgz#5c09e3e6454c6d05ed8da4a0d9adaf11d9fd7908"
-  integrity sha512-VCcsaSY2IUL3dylB0QF0P5QfpYybKU4uM0dVGJ044S7JS6Bp3wL51OwYSbHGYF3b8V7UgBQYVEf/zaP3ziCGDQ==
+"@sanity/export@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/export/-/export-3.0.0-rc.3.tgz#16ece11bfc4eb9364b38fa3ffd1bad17d0bbdaa5"
+  integrity sha512-5cK5JCUBgZnAtrN10NM3Ec5BJajGafprewpuBiLXDpxn33oefJq0SLc1O/+8hnWAy6DHdnT+LXYGj47Wn+IXPw==
   dependencies:
     archiver "^5.0.0"
     debug "^3.2.7"
@@ -765,29 +826,29 @@
     split2 "^4.1.0"
     throttle-debounce "^5.0.0"
 
-"@sanity/icons@1.3.9-beta.3":
-  version "1.3.9-beta.3"
-  resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-1.3.9-beta.3.tgz#3ea91b07ad62ff23a601a320dedcfd17349e78a5"
-  integrity sha512-IHacaR96czI6402cBlkiKqmi7AASj3jLVYZ8dTD9caRGi0Dp7eJzI9RFp0ptJNxQYdYbZCZu0D/oEdhJfHEMGA==
-
-"@sanity/icons@^1.2.8", "@sanity/icons@^1.3":
+"@sanity/icons@^1.3":
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-1.3.6.tgz#4de4848304bf8487e1c08188decbb0ba5e86a158"
   integrity sha512-/GeFmwHMQVTCBvo4qAQgZJHKB1UzU8u42gnjs6696PWh626G4xbElb3/YJ9sM1PwTc0OaYrvIDes8qUTvrlhrA==
+
+"@sanity/icons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-2.0.0.tgz#16dc4454e65f0f95bd1a130fb0b06681a017eb54"
+  integrity sha512-TLrJ9YXUzZeb1gijjCkERaie1LipSYfC/7KKIzJxGxPfxq+90HRklo/zzVFk45GctXFhxJRgMA5sbkCDVb9RiA==
 
 "@sanity/image-url@^1.0.0", "@sanity/image-url@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.1.tgz#960d649b2f4396da0adb31cf94503c929495cea0"
   integrity sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg==
 
-"@sanity/import@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/import/-/import-3.0.0-rc.0.tgz#ed6e2461c43948e698b245d1ffe9a3cbbc3a5057"
-  integrity sha512-UF1FBsmw3N6Eo8vJTDngqfUs7pobSIqleczlSpnZMlt+ETikT3/0gTJvkiXAT1VAXaQCeSjASUCPMO+HWtbH5A==
+"@sanity/import@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/import/-/import-3.0.0-rc.3.tgz#5188d6727cc30e13792e5ae654a1228205ee9b4e"
+  integrity sha512-nzwMCQKp016scn8Hg6a9RjWyKsTGz/EFUeQVRUTKFy0t9/3BqyvSKkbOFxfgjNE6/HhykKu1HCrq8XvtbgEUog==
   dependencies:
     "@sanity/asset-utils" "^1.2.5"
     "@sanity/generate-help-url" "^3.0.0"
-    "@sanity/mutator" "3.0.0-rc.0"
+    "@sanity/mutator" "3.0.0-rc.3"
     "@sanity/uuid" "^3.0.1"
     debug "^3.2.7"
     file-url "^2.0.2"
@@ -812,15 +873,15 @@
     "@sanity/icons" "^1.3"
     react-copy-to-clipboard "^5.1.0"
 
-"@sanity/logos@1.1.20-beta.3":
-  version "1.1.20-beta.3"
-  resolved "https://registry.yarnpkg.com/@sanity/logos/-/logos-1.1.20-beta.3.tgz#40e24269cfa25b20b6b05ecefa5847ce3350e976"
-  integrity sha512-aMxqGIemeO12BxbpWD+5dQeTK2maYRsLa4f5cdr+ah9uyfooNTmpz9vQlSaukyUIKG+Skzx+aMzj1qWjzB2pig==
+"@sanity/logos@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@sanity/logos/-/logos-2.0.2.tgz#d1b10a32e51d0c35ecbd32b43991a7c89f77a5f6"
+  integrity sha512-BsBNt4ldWNAuKeHge4nKHnN43BN8BwLJuf+HDhrg/ngnORUjty5WV4KVoQkQ2FSTv5YtpJjSuNGSXwT+Araegw==
 
-"@sanity/mutator@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/mutator/-/mutator-3.0.0-rc.0.tgz#570cbbdda635c68abdeaa69ee3e1e759b0ec30eb"
-  integrity sha512-Ehwg5JG1eBzXDEBaq5rdquNWYwJsOMlyuIoKwaYQHFUQIx8XpocNjBwGQEGodXoyze9WrRB71V1pWXojmO82sA==
+"@sanity/mutator@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/mutator/-/mutator-3.0.0-rc.3.tgz#0faab8e92168d28ea1b1333d8b17a965e493f3cf"
+  integrity sha512-luNWfUCUSWXK/sEJR9B3a6DfuqrbUYR0M8zFR87c5teICvAgZbZx1uBwpNu3C8E5F8jIGSeVCmlgjYZKlwRXoA==
   dependencies:
     "@sanity/uuid" "^3.0.1"
     "@types/diff-match-patch" "^1.0.32"
@@ -828,16 +889,16 @@
     diff-match-patch "^1.0.4"
     lodash "^4.17.21"
 
-"@sanity/portable-text-editor@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-rc.0.tgz#070a8dd11c71c68aebaac5fe77b1ed566a93766b"
-  integrity sha512-0Eq+ZYwWvOdFVwH2DAm0IKu2rKQ8vkGhwPjdBATvNeOmV1o9ySHwotxDQ4jBeRU/EB1WoaFb58jNlh+xMVTljg==
+"@sanity/portable-text-editor@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/portable-text-editor/-/portable-text-editor-3.0.0-rc.3.tgz#d9f380ffebbabf51f32fdffd2b0483f36285a006"
+  integrity sha512-cKOk+/RHaeQg5ObNEajOS6DqP0pVNRrnYXUHcgbqaNrqX5A4uU/c/B3MqnawGo/aUtE+wJH0x30+5qGPkzkdLg==
   dependencies:
-    "@sanity/block-tools" "3.0.0-rc.0"
-    "@sanity/schema" "3.0.0-rc.0"
+    "@sanity/block-tools" "3.0.0-rc.3"
+    "@sanity/schema" "3.0.0-rc.3"
     "@sanity/slate-react" "2.30.1"
-    "@sanity/types" "3.0.0-rc.0"
-    "@sanity/util" "3.0.0-rc.0"
+    "@sanity/types" "3.0.0-rc.3"
+    "@sanity/util" "3.0.0-rc.3"
     debug "^3.2.7"
     is-hotkey "^0.1.6"
     lodash "^4.17.21"
@@ -853,23 +914,23 @@
     event-source-polyfill "^1.0.31"
     suspend-react "0.0.8"
 
-"@sanity/schema@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/schema/-/schema-3.0.0-rc.0.tgz#8865a0061d5dabd9e103024e9adb7042dcbd90a3"
-  integrity sha512-r8xHjY4osTWzBpKIO69r9POWShcyiGyTsXk5AUA7EXPULnOBl+6qzQNbdHkKA75WoK28dZ33JIXVY1RhCc7bkQ==
+"@sanity/schema@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/schema/-/schema-3.0.0-rc.3.tgz#e3d894e2759419123faacbcdeb8276ac34806199"
+  integrity sha512-/+SJ27BIGslFwrg159FiljJNEWHIcwMEljCdsxFHj7isINZh/xp7iqMANxGZwsAdXlHaq51437DnO6DDTf+vBA==
   dependencies:
     "@sanity/generate-help-url" "^3.0.0"
-    "@sanity/types" "3.0.0-rc.0"
+    "@sanity/types" "3.0.0-rc.3"
     arrify "^1.0.1"
     humanize-list "^1.0.1"
     leven "^3.1.0"
     lodash "^4.17.21"
     object-inspect "^1.6.0"
 
-"@sanity/server@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/server/-/server-3.0.0-rc.0.tgz#d244b686de85e35296239e72cf651dc7d8803d07"
-  integrity sha512-P45vBjc4tG8S4CAeR5xfH4OZbPDzawwT/BBKuiMQitP0MjlmwpYeGKDQlSqyLlQM2O9zPIk0Yztk/BBi6f3w9Q==
+"@sanity/server@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/server/-/server-3.0.0-rc.3.tgz#3c41658d6358a322bef8c6c69b572ae9be1e168e"
+  integrity sha512-VfJsM28+VYFx1FsaAaNX+Y3XaZ8TlP39JODPXYr6zrDXficFMxrgHEYaZSVhfw58E6Qf1/TNR7hFl3ZFN3p3Ng==
   dependencies:
     "@sanity/generate-help-url" "^3.0.0"
     "@vitejs/plugin-react" "^2.0.0"
@@ -904,13 +965,13 @@
   resolved "https://registry.yarnpkg.com/@sanity/timed-out/-/timed-out-4.0.2.tgz#c9f61f9a1609baa1eb3e4235a24ea2a775022cdf"
   integrity sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==
 
-"@sanity/types@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/types/-/types-3.0.0-rc.0.tgz#a6ab32c3a89f42a006ff7384d69acae71d7f467a"
-  integrity sha512-mq2ybbvdxcJcu/+81oSZdFz7+d0R/jcsPjfWlR+kOjcIqlgIbLI6+uItcFS/Vo2uY+D1u8i8kQ2SRg0S+AL04A==
+"@sanity/types@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/types/-/types-3.0.0-rc.3.tgz#a5d8e7419b1aedf2185c3b974b3a39a62518d67e"
+  integrity sha512-PgVW6sHuMe2bnXm1idPdxWGmKPeGfsnYMrcSpXyt5qKtOwMGPJsw2fbTfhdQEE40pRWiA1n9h+KO6GXytJsNlA==
   dependencies:
     "@sanity/client" "^3.4.1"
-    "@types/react" "^18.0.21"
+    "@types/react" "^18.0.25"
 
 "@sanity/types@^2.35.0":
   version "2.35.0"
@@ -922,23 +983,24 @@
     "@types/react" "^17.0.42"
     rxjs "^6.5.3"
 
-"@sanity/ui@1.0.0-beta.32":
-  version "1.0.0-beta.32"
-  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.0.0-beta.32.tgz#5b057e7579c0769c9ae86cdc2442d2d6f12525ef"
-  integrity sha512-mzJXwdevJr/LAPnXHFnkhs4fXEuS7uDQqnvPRdX9t76GG9diyW5TOBemsujuFk4qFRKRUzgFDM3CyqllWbL2zw==
+"@sanity/ui@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.0.0.tgz#afa27e51a58fb9cf9818be1ce5f21df84c25d1fc"
+  integrity sha512-Ru0ZaKValcOsSj3yaC1G+oBn+t4egtSMnrw22cg3fpuDvWN7Oj4cZVaTUBmggUDSeP8+wsSO3crZ87aHC9H1Hw==
   dependencies:
     "@floating-ui/react-dom" "^1.0.0"
-    "@sanity/color" "2.1.19-beta.3"
-    "@sanity/icons" "1.3.9-beta.3"
+    "@sanity/color" "^2.1.20"
+    "@sanity/icons" "^2.0.0"
+    csstype "^3.1.1"
     framer-motion "^7.5.3"
     react-refractor "^2.1.7"
 
-"@sanity/util@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/util/-/util-3.0.0-rc.0.tgz#a46b3d54c2608b8b83e1e2e54e0e3e275b91f338"
-  integrity sha512-pibawRcTK9l8FT2164BzMNyoU7u5hILGZAy5D+niQm9GAY8S82DFbwR/7gTCYklK9RVbtfZa8BgGZntWDQctIg==
+"@sanity/util@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/util/-/util-3.0.0-rc.3.tgz#8ac69926b26efd53242b1fae783a05ed6c2caf4d"
+  integrity sha512-qC1aa39jnbpIcNuikhX6iT1YWTMMMIROlJn6KupYo5hUOKKgqqJo9O9qY5GsQjY4rl+1zZFg+B289dtyQ8r3tg==
   dependencies:
-    "@sanity/types" "3.0.0-rc.0"
+    "@sanity/types" "3.0.0-rc.3"
     get-random-values-esm "^1.0.0"
     moment "^2.29.4"
 
@@ -950,12 +1012,12 @@
     "@types/uuid" "^8.0.0"
     uuid "^8.0.0"
 
-"@sanity/validation@3.0.0-rc.0":
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@sanity/validation/-/validation-3.0.0-rc.0.tgz#2e04da8382177a37140b7702bdad6762ce338ba0"
-  integrity sha512-mCxLw2j/m08Y/E1r2+WHxkCWziK7jI03J1QxglgtbhoH3w04ajbKpxI3hX9Q8O9IDmPlYOHeWLJmaxBqJF9CNA==
+"@sanity/validation@3.0.0-rc.3":
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@sanity/validation/-/validation-3.0.0-rc.3.tgz#0250791569a3878cb8f39d15deb66ffab1136edf"
+  integrity sha512-ZDLOz/KJIqb/t5wkIaPdeOT/eNVQSMW6RgOjQ6GPHZYJB3cGgEAnrDgHMymf6VrGRltKE7woMfk67zr+Zch3gg==
   dependencies:
-    "@sanity/types" "3.0.0-rc.0"
+    "@sanity/types" "3.0.0-rc.3"
     date-fns "^2.26.1"
     lodash "^4.17.21"
     rxjs "^6.5.3"
@@ -983,10 +1045,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tailwindcss/typography@0.5.8":
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.8.tgz#8fb31db5ab0590be6dfa062b1535ac86ad9d12bf"
-  integrity sha512-xGQEp8KXN8Sd8m6R4xYmwxghmswrd0cPnNI2Lc6fmrC3OojysTBJJGSIVwPV56q4t6THFUK3HJ0EaWwpglSxWw==
+"@tailwindcss/typography@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.7.tgz#e0b95bea787ee14c5a34a74fc824e6fe86ea8855"
+  integrity sha512-JTTSTrgZfp6Ki4svhPA4mkd9nmQ/j9EfE7SbHJ1cLtthKkpW2OxsFXzSmxbhYbEkfNIyAyhle5p4SYyKRbz/jg==
   dependencies:
     lodash.castarray "^4.4.0"
     lodash.isplainobject "^4.0.6"
@@ -1084,7 +1146,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.21":
+"@types/react@*", "@types/react@^18.0.25":
   version "18.0.25"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
   integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
@@ -1190,13 +1252,13 @@
   resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-0.1.5.tgz#285275b64a5b47cae0e5d11002fb8856b1ec6b0c"
   integrity sha512-/k9N8Ea3Yc5A52GlkjzUEbi2vE/izClrOf++ryBkxEfrZM/OZwtHkdNw/QExZ1h/B67RCZLK7bCOnKKrhG7gTg==
 
-"@vercel/og@0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@vercel/og/-/og-0.0.21.tgz#9d2421a241a0cfbdc3841b88bf323d980339da40"
-  integrity sha512-WgMahG5c8UM7xtn/mT+ljUpDMSDnSlu8AXL52JtTwxb1odrd0GWqZg2N1X38wulPj+sCccNpDdFmmAuw0GLc+Q==
+"@vercel/og@0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@vercel/og/-/og-0.0.20.tgz#fe586d153e492edd87fe2bc2671ba223072bd47a"
+  integrity sha512-089P+TfqWz0xBxjOvOhkZIDDtfrLcye94H4IZ+SqxoGPWpNGXaBvRJER/z5SoJxJRcCAL8tPiK5zdjRskM6tLw==
   dependencies:
     "@resvg/resvg-wasm" "2.0.0-alpha.4"
-    satori "0.0.44"
+    satori "0.0.43"
     yoga-wasm-web "0.1.2"
 
 "@vitejs/plugin-react@^2.0.0":
@@ -1443,6 +1505,22 @@ axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
+
+"babel-plugin-styled-components@>= 1.12.0":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
+  integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-module-imports" "^7.16.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+    picomatch "^2.3.0"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1839,7 +1917,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2:
+csstype@^3.0.2, csstype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
@@ -3273,6 +3351,13 @@ history@^4.6.3:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
+hoist-non-react-statics@^3.0.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -3835,7 +3920,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==
 
-lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4398,7 +4483,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.0, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -4701,7 +4786,7 @@ react-focus-lock@^2.8.1:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -4981,10 +5066,10 @@ sanity-diff-patch@^1.0.9:
   dependencies:
     diff-match-patch "^1.0.5"
 
-sanity@3.0.0-rc.0:
-  version "3.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/sanity/-/sanity-3.0.0-rc.0.tgz#99c63ed83f5ac84fa1f1c5d688c52fd5ee96ef25"
-  integrity sha512-ZIKDWoVUjBP8OtHV/Rs5QBmrqBuxzJsOh6JJHgb5sq6dKw7tCN+HAfFIXl1afC5ngZPNbArhFGL9ExD9Z9ldAg==
+sanity@3.0.0-rc.3:
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/sanity/-/sanity-3.0.0-rc.3.tgz#e67dd51b78b7066fd551880c5b17aac8e63fa914"
+  integrity sha512-7Il5aTeq1pZ8o4g1rKsF2dcyvMSj9/f7N1pqbICX1DNvfil+njHTg1WniOOskqna4+nWYuhhEQAaDPynSDofZg==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@portabletext/react" "^1.0.6"
@@ -4993,27 +5078,27 @@ sanity@3.0.0-rc.0:
     "@rexxars/react-sortable-hoc" "^2.0.0"
     "@sanity/asset-utils" "^1.2.5"
     "@sanity/bifur-client" "^0.3.0"
-    "@sanity/block-tools" "3.0.0-rc.0"
-    "@sanity/cli" "3.0.0-rc.0"
+    "@sanity/block-tools" "3.0.0-rc.3"
+    "@sanity/cli" "3.0.0-rc.3"
     "@sanity/client" "^3.4.1"
-    "@sanity/color" "2.1.19-beta.3"
-    "@sanity/diff" "3.0.0-rc.0"
+    "@sanity/color" "^2.1.20"
+    "@sanity/diff" "3.0.0-rc.3"
     "@sanity/eventsource" "^3.0.1"
-    "@sanity/export" "3.0.0-rc.0"
+    "@sanity/export" "3.0.0-rc.3"
     "@sanity/generate-help-url" "^3.0.0"
-    "@sanity/icons" "1.3.9-beta.3"
+    "@sanity/icons" "^2.0.0"
     "@sanity/image-url" "^1.0.1"
-    "@sanity/import" "3.0.0-rc.0"
-    "@sanity/logos" "1.1.20-beta.3"
-    "@sanity/mutator" "3.0.0-rc.0"
-    "@sanity/portable-text-editor" "3.0.0-rc.0"
-    "@sanity/schema" "3.0.0-rc.0"
-    "@sanity/server" "3.0.0-rc.0"
-    "@sanity/types" "3.0.0-rc.0"
-    "@sanity/ui" "1.0.0-beta.32"
-    "@sanity/util" "3.0.0-rc.0"
+    "@sanity/import" "3.0.0-rc.3"
+    "@sanity/logos" "^2.0.2"
+    "@sanity/mutator" "3.0.0-rc.3"
+    "@sanity/portable-text-editor" "3.0.0-rc.3"
+    "@sanity/schema" "3.0.0-rc.3"
+    "@sanity/server" "3.0.0-rc.3"
+    "@sanity/types" "3.0.0-rc.3"
+    "@sanity/ui" "^1.0.0"
+    "@sanity/util" "3.0.0-rc.3"
     "@sanity/uuid" "^3.0.1"
-    "@sanity/validation" "3.0.0-rc.0"
+    "@sanity/validation" "3.0.0-rc.3"
     "@tanstack/react-virtual" "3.0.0-beta.18"
     "@types/is-hotkey" "^0.1.7"
     "@types/react-copy-to-clipboard" "^5.0.2"
@@ -5083,10 +5168,10 @@ sanity@3.0.0-rc.0:
     use-hot-module-reload "^1.0.1"
     yargs "^17.3.0"
 
-satori@0.0.44:
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/satori/-/satori-0.0.44.tgz#278d2c383a3248973c93843c0f72da5c69c9eafa"
-  integrity sha512-WKUxXC2qeyno6J3ucwwLozPL6j1HXOZiN5wIUf7iqAhlx1RUC/6ePIKHi7iPc3Cy6DYuZcJriZXxXkSdo2FQHg==
+satori@0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/satori/-/satori-0.0.43.tgz#865b80feed473fc254e389fa7c0bd4c1d8e9aad7"
+  integrity sha512-SzYwr+LsELWRJU9KMviEOE9TdShry+R5AdS54YQvgAVKFDN4yniAIzwQk1/z2TtIx0ceUT9zTeosWAoWvJBEtQ==
   dependencies:
     "@shuding/opentype.js" "1.4.0-beta.0"
     css-background-parser "^0.1.0"
@@ -5143,6 +5228,11 @@ shallow-equals@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shallow-equals/-/shallow-equals-1.0.0.tgz#24b74bf1c634c11ed4c7182a6df6fb300dce4390"
   integrity sha512-xd/FKcdmfmMbyYCca3QTVEJtqUOGuajNzvAX6nt8dXILwjAIEkfHc4hI8/JMGApAmb7VeULO0Q30NTxnbH/15g==
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -5392,6 +5482,22 @@ style-value-types@5.1.2:
     hey-listen "^1.0.8"
     tslib "2.4.0"
 
+styled-components@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.6.tgz#27753c8c27c650bee9358e343fc927966bfd00d1"
+  integrity sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^1.1.0"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1.12.0"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 styled-jsx@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.0.tgz#4a5622ab9714bd3fcfaeec292aa555871f057563"
@@ -5399,7 +5505,7 @@ styled-jsx@5.1.0:
   dependencies:
     client-only "0.0.1"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,10 +748,10 @@
     object-assign "^4.1.1"
     rxjs "^6.0.0"
 
-"@sanity/code-input@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/code-input/-/code-input-3.0.0.tgz#ca4d01a9cdb956b8321d3d745dc39462d4de6df1"
-  integrity sha512-Ov6csC/t2i6qZbbylGodhMmaygsX/t/TxjCG1L+oGPJNXu3mXQDG8/3PQmZl1Zac1Do90+72eK4/x/xj/+QHBA==
+"@sanity/code-input@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sanity/code-input/-/code-input-3.0.1.tgz#201d943360258c487e5fc49e08816de4b9cdd3ec"
+  integrity sha512-45EsvoBHP1jTSS87T4pxNj3qzAeSmA9TlPavgb9XagiNjy970nAYYQvggpg/46zu0BJMz2YnzXPAAc0kkHYhtA==
   dependencies:
     "@sanity/icons" "^2.0.0"
     "@sanity/incompatible-plugin" "^1.0.4"


### PR DESCRIPTION
It's not supported to import the `sanity` package in RSC routes, it only works if you're in a `use client` route. 

Thus client config for `projectId`, `dataset` etc needs to be in a tiny file that can be safely imported in both server-only and client-only environments.